### PR TITLE
choose vector database using env config

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,11 +12,11 @@ OPENAI_API_KEY=sk-****
 # Replicate related environment variables
 REPLICATE_API_TOKEN=r8_****
 
-# Pinecone related environment variables
-PINECONE_API_KEY=bb****
+# Pinecone related environment variables (optional; comment these out if not using Pinecone)
+PINECONE_API_KEY=****
 PINECONE_ENVIRONMENT=us****
-PINECONE_INDEX=ai****
+PINECONE_INDEX=****
 
-# Supabase related environment variables
+# Supabase related environment variables (optional; comment these out if not using Supabase)
 SUPABASE_URL=https://****
 SUPABASE_PRIVATE_KEY=eyJ****

--- a/README.md
+++ b/README.md
@@ -79,17 +79,23 @@ e. **Supabase API key**
 There are a few markdown files under `/blogs` directory as examples so you can do Q&A on them. To generate embeddings and store them in the vector database for future queries, you can run the following command: 
 
 #### If using Pinecone
-Run the following command to generate embeddings and store them in Pinecone: 
+
+1. Set all requird Pinecone environment variables in `.env.local` file.
+1. Remove Supabase environment variables from `.env.local` file.
+1. Run the following command to generate embeddings and store them in Pinecone: 
+
 ```bash
 npm run generate-embeddings-pinecone
 ```
 #### If using Supabase pgvector
-In `QAModel.tsx`, replace `/api/qa-pinecone` with `/api/qa-pg-vector`. Then run the following command to generate embeddings and store them in Supabase pgvector:
+
+1. Set all required Supabase environment variables in `.env.local` file.
+1. Remove Pinecone environment variables from `.env.local` file.
+1. Run the following command to generate embeddings and store them in Supabase pgvector:
 
 ```bash
 npm run generate-embeddings-supabase
 ```
-
 
 ### 5. Run app locally
 

--- a/src/components/QAModal.tsx
+++ b/src/components/QAModal.tsx
@@ -11,7 +11,7 @@ export default function QAModal({
 }) {
   const { completion, input, isLoading, handleInputChange, handleSubmit } =
     useCompletion({
-      api: "/api/qa-pinecone",
+      api: (process.env.PINECONE_API_KEY ? "/api/qa-pinecone" : "/api/qa-pg-vector"),
     });
 
   return (


### PR DESCRIPTION
This PR attempts to simplify the process of using Pinecone or Supabase. Rather than requiring the user of the app to change code references, it adds a bit of logic to select the appropriate API adapter based on the presence or absence of the Pinecone API key.

With this change in place, users will be able to control which database they're using without changing any code.