### PR TITLE
appease React by camelCasing strokeWidth

### DIFF
--- a/src/components/QAModal.tsx
+++ b/src/components/QAModal.tsx
@@ -82,7 +82,7 @@ export default function QAModal({
                             cy="12"
                             r="10"
                             stroke="currentColor"
-                            stroke-width="4"
+                            strokeWidth="4"
                           ></circle>
                           <path
                             className="opacity-75"

--- a/src/components/TextToImgModal.tsx
+++ b/src/components/TextToImgModal.tsx
@@ -107,7 +107,7 @@ export default function TextToImgModal({
                         cy="12"
                         r="10"
                         stroke="currentColor"
-                        stroke-width="4"
+                        strokeWidth="4"
                       ></circle>
                       <path
                         className="opacity-75"


### PR DESCRIPTION
Resolves this warning:

<img width="652" alt="Screenshot 2023-06-25 at 2 40 25 PM" src="https://github.com/a16z-infra/ai-getting-started/assets/2289/8fa5c62c-2ad4-4c49-8d08-cbb8c64af8dc">


