### PR TITLE
Added document chunking

### DIFF
--- a/src/scripts/indexBlogs.mjs
+++ b/src/scripts/indexBlogs.mjs
@@ -9,13 +9,37 @@ import path from "path";
 
 dotenv.config({ path: `.env.local` });
 
+const MAX_TOKENS = 8191;
+
 const fileNames = fs.readdirSync("blogs");
-const lanchainDocs = fileNames.map((fileName) => {
+
+// Helper function to chunk a string into smaller parts
+const chunkString = (str, length) => {
+  const size = Math.ceil(str.length / length);
+  const r = Array(size);
+  let offset = 0;
+
+  for (let i = 0; i < size; i++) {
+    r[i] = str.substr(offset, length);
+    offset += length;
+  }
+
+  return r;
+};
+
+const lanchainDocs = [];
+
+fileNames.forEach((fileName) => {
   const filePath = path.join("blogs", fileName);
   const fileContent = fs.readFileSync(filePath, "utf8");
-  return new Document({
-    metadata: { fileName },
-    pageContent: fileContent,
+
+  const chunks = chunkString(fileContent, MAX_TOKENS);
+  
+  chunks.forEach((chunk, index) => {
+    lanchainDocs.push(new Document({
+      metadata: { fileName, chunkIndex: index },
+      pageContent: chunk,
+    }));
   });
 });
 


### PR DESCRIPTION
When uploading a corpus of documents with more than 8191 tokens, the Pinecone API returns an error.

This PR chunks the documents and sends them in a list.